### PR TITLE
Pass the file name to stylelint

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@
 const path = require('path');
 
 const langServer = require('vscode-languageserver');
+const Files = langServer.Files;
 const stylelintVSCode = require('stylelint-vscode');
 
 let configBasedir;
@@ -20,6 +21,7 @@ const syntaxConfig = {
 function validate(document) {
   return stylelintVSCode({
     code: document.getText(),
+    codeFilename: Files.uriToFilePath(document.uri),
     config,
     configOverrides,
     configBasedir,


### PR DESCRIPTION
Fixes shinnn/vscode-stylelint#22 and other issues related to a missing
file name. For example,
https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/partial-no-import/README.md
doesn't work without this parameter.