### PR TITLE
Make SCSS the default syntax, as it's safer

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,6 +31,8 @@ function validate(document) {
 
   if (supportedCustomSyntaxes.has(document.languageId)) {
     options.syntax = document.languageId;
+  } else {
+    options.syntax = 'scss';
   }
 
   return stylelintVSCode(options).then(diagnostics => {


### PR DESCRIPTION
I think SCSS might be a safer syntax default, since it will correctly parse both CSS and SCSS. 

Thinking longer term, I think this extension may need a `stylelint.syntax` option. Otherwise, there's no way to specify an alternative syntax for `additionalDocumentSelectors` such as `"vue"`.