### PR TITLE
Allow styled-components processor to be installed a deep folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"onLanguage:vue",
 		"onLanguage:vue-html",
 		"onLanguage:xml",
-		"workspaceContains:node_modules/stylelint-processor-styled-components/package.json"
+		"workspaceContains:**/node_modules/stylelint-processor-styled-components/package.json"
 	],
 	"main": "index.js",
 	"contributes": {


### PR DESCRIPTION
If node_modules is in a subdirectory then stylelint is not activated for styled components processor.
This glob pattern should handle it properly.